### PR TITLE
Added files to CMakeLists.txt to fix linking errors;

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,10 +12,12 @@ set(
   PACKETSENDER_UI_HEADERS
   about.h
   brucethepoodle.h
+  mainpacketreceiver.h
   mainwindow.h
   panel.h
   panelgenerator.h
   persistentconnection.h
+  persistenthttp.h
   postdatagen.h
   settings.h
   udpflooding.h
@@ -30,6 +32,7 @@ set(
   multicastsetup.ui
   panelgenerator.ui
   persistentconnection.ui
+  persistenthttp.ui
   postdatagen.ui
   settings.ui
   subnetcalc.ui
@@ -42,6 +45,7 @@ set(
   brucethepoodle.cpp
   cloudui.cpp
   main.cpp
+  mainpacketreceiver.cpp
   mainwindow.cpp
   multicastsetup.cpp
   packet.cpp
@@ -50,6 +54,7 @@ set(
   panel.cpp
   panelgenerator.cpp
   persistentconnection.cpp
+  persistenthttp.cpp
   postdatagen.cpp
   sendpacketbutton.cpp
   settings.cpp


### PR DESCRIPTION
I cloned the repo and attempted to build with CMake but ran into linking errors. There were some files missing from the CMakeLists.txt file. Once I made these changes I was able to build.
