### PR TITLE
Fix icon path in .desktop file

### DIFF
--- a/src/packetsender.desktop
+++ b/src/packetsender.desktop
@@ -2,7 +2,7 @@
 Name=Packet Sender
 Comment=Network utility for sending and receiving TCP, UDP, SSL packets
 Exec=/usr/bin/packetsender
-Icon=/usr/share/icons/packetsender
+Icon=packetsender
 Terminal=false
 Type=Application
 Categories=Network;


### PR DESCRIPTION
All systems must be able to find an icon recursively inside /usr/share/icons/ when a app name is declared.

E.g., Debian will use /usr/share/icons/hicolor/128x128/apps/ for packetsender.png and /usr/share/icons/hicolor/scalable/apps/ for src/packetsender.svg.

Before submitting a pull request:

- Did you fork from the development branch?
- Are you submitting the pull request to the development branch? (not master)
