### PR TITLE
Restore Snap Supportu

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -33,10 +33,11 @@ apps:
       
 parts:
   packetsender:
-    plugin: qmake
+    plugin: cmake
     source: https://github.com/dannagle/PacketSender.git
     source-branch: master
-    qmake-project-file: src/PacketSenderSnap.pro
+    cmake-parameters:
+      - /root/project/src/snap
     build-packages:
       - build-essential
       - qt6-base-dev

--- a/src/snap/CMakeLists.txt
+++ b/src/snap/CMakeLists.txt
@@ -1,0 +1,135 @@
+cmake_minimum_required(VERSION 3.16)
+project(packetsender VERSION 1.0 LANGUAGES C CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(SRCROOT /root/project/src)
+
+include_directories(${SRCROOT})
+
+# Set up AUTOMOC and some sensible defaults for runtime execution
+# When using Qt 6.3, you can replace the code block below with
+# qt_standard_project_setup()
+set(CMAKE_AUTOMOC ON)
+include(GNUInstallDirs)
+set(CMAKE_AUTOUIC ON)
+
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Network Widgets)
+
+set(SOURCES
+    ${SRCROOT}/about.cpp
+    ${SRCROOT}/brucethepoodle.cpp
+    ${SRCROOT}/cloudui.cpp
+    ${SRCROOT}/irisandmarigold.cpp
+    ${SRCROOT}/languagechooser.cpp
+    ${SRCROOT}/main.cpp
+    ${SRCROOT}/mainpacketreceiver.cpp
+    ${SRCROOT}/mainwindow.cpp
+    ${SRCROOT}/multicastsetup.cpp
+    ${SRCROOT}/packet.cpp
+    ${SRCROOT}/packetlogmodel.cpp
+    ${SRCROOT}/packetnetwork.cpp
+    ${SRCROOT}/panel.cpp
+    ${SRCROOT}/panelgenerator.cpp
+    ${SRCROOT}/persistentconnection.cpp
+    ${SRCROOT}/persistenthttp.cpp
+    ${SRCROOT}/postdatagen.cpp
+    ${SRCROOT}/sendpacketbutton.cpp
+    ${SRCROOT}/settings.cpp
+    ${SRCROOT}/subnetcalc.cpp
+    ${SRCROOT}/tcpthread.cpp
+    ${SRCROOT}/threadedtcpserver.cpp
+    ${SRCROOT}/udpflooding.cpp
+    ${SRCROOT}/wakeonlan.cpp
+)
+
+set(HEADERS 
+    ${SRCROOT}/about.h
+    ${SRCROOT}/brucethepoodle.h
+    ${SRCROOT}/cloudui.h
+    ${SRCROOT}/globals.h
+    ${SRCROOT}/irisandmarigold.h
+    ${SRCROOT}/languagechooser.h
+    ${SRCROOT}/mainpacketreceiver.h
+    ${SRCROOT}/mainwindow.h
+    ${SRCROOT}/multicastsetup.h
+    ${SRCROOT}/packet.h
+    ${SRCROOT}/packetlogmodel.h
+    ${SRCROOT}/packetnetwork.h
+    ${SRCROOT}/panel.h
+    ${SRCROOT}/panelgenerator.h
+    ${SRCROOT}/persistenthttp.h
+    ${SRCROOT}/postdatagen.h
+    ${SRCROOT}/sendpacketbutton.h
+    ${SRCROOT}/settings.h
+    ${SRCROOT}/subnetcalc.h
+    ${SRCROOT}/tcpthread.h
+    ${SRCROOT}/threadedtcpserver.h
+    ${SRCROOT}/udpflooding.h
+    ${SRCROOT}/wakeonlan.h
+)
+
+set(FORMS 
+    ${SRCROOT}/about.ui
+    ${SRCROOT}/brucethepoodle.ui
+    ${SRCROOT}/cloudui.ui
+    ${SRCROOT}/irisandmarigold.ui
+    ${SRCROOT}/languagechooser.ui
+    ${SRCROOT}/mainwindow.ui
+    ${SRCROOT}/multicastsetup.ui
+    ${SRCROOT}/panelgenerator.ui
+    ${SRCROOT}/persistentconnection.ui
+    ${SRCROOT}/persistenthttp.ui
+    ${SRCROOT}/postdatagen.ui
+    ${SRCROOT}/settings.ui
+    ${SRCROOT}/subnetcalc.ui
+    ${SRCROOT}/udpflooding.ui
+    ${SRCROOT}/wakeonlan.ui
+
+)
+
+qt_add_resources(RESOURCES ${SRCROOT}/packetsender.qrc ${SRCROOT}/translations.qrc ${SRCROOT}/qdarkstyle/style.qrc)
+
+set(CSS
+    ${SRCROOT}/packetsender.css
+)
+
+qt_add_executable(packetsender 
+    ${SOURCES} ${HEADERS} ${FORMS} ${RESOURCES} ${CSS}
+)
+
+execute_process(COMMAND git -C ${SRCROOT}/ rev-parse --short HEAD OUTPUT_VARIABLE GIT_SHA COMMAND_ERROR_IS_FATAL ANY OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+target_compile_definitions(packetsender PRIVATE
+    GUI_BUILD
+    ISSNAP=1
+    QT_DISABLE_DEPRECATED_BEFORE=0x050F00
+    GIT_CURRENT_SHA1=\"${GIT_SHA}\"
+)
+
+
+target_link_libraries(packetsender PRIVATE
+    Qt::Core
+    Qt::Gui
+    Qt::Network
+    Qt::Widgets
+)
+
+
+
+target_compile_definitions(packetsender PRIVATE
+    _FORTIFY_SOURCE=2
+)
+
+
+install(TARGETS packetsender
+    BUNDLE DESTINATION .
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(FILES ${SRCROOT}/packetsender.desktop DESTINATION /usr/share/applications)
+install(FILES ${SRCROOT}/packetsender.svg DESTINATION /usr/share/icons)
+
+# Consider using qt_generate_deploy_app_script() for app deployment if
+# the project can use Qt 6.3. In that case rerun qmake2cmake with
+# --min-qt-version=6.3.


### PR DESCRIPTION
Create new cmake file and alter snapcraft.yaml to build snap builds once more. Due to core22 not supporting qmake yet [1] and Qt not continuing to support qmake[2], this commit moves Packet Sender snap builds to cmake. In order to not mess with Debian builds (Which use the existing CMakeLists.txt), a new CMakeLists.txt has been added under a snap directory

The alterations were generated by using qmake2cmake [3] on the .pro file for snap builds, and then merged under if statements for the existing CMakeLists.txt. I did have to comment out the git sha generation and add that back manually for the tool to work, as well as specify source root manually.

[1] https://forum.snapcraft.io/t/core22-qmake-plugin-support/35026
[2] https://www.qt.io/blog/2019/08/07/technical-vision-qt-6
[3] https://code.qt.io/cgit/qt/qmake2cmake.git/about/

Before submitting a pull request:

- Did you fork from the development branch?
- Are you submitting the pull request to the development branch? (not master)
