### PR TITLE
Support partials smart responses

### DIFF
--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -860,6 +860,7 @@ SmartResponseConfig Packet::fetchSmartConfig(int num, QString importFile)
     smart.ifEquals = settings.value("responseIfEdit" + QString::number(num), "").toString();
     smart.replyWith = settings.value("responseReplyEdit" + QString::number(num), "").toString();
     smart.enabled = settings.value("responseEnableCheck" + QString::number(num), false).toBool();
+    smart.matchMethod = settings.value("matchMethodBox" + QString::number(num), "").toString();
 
     return smart;
 }
@@ -1014,8 +1015,27 @@ QByteArray Packet::smartResponseMatch(QList<SmartResponseConfig> smartList, QByt
 
     foreach (config, smartList) {
         if (config.enabled) {
+            bool matched = false;
             QByteArray testData = Packet::encodingToByteArray(config.encoding, config.ifEquals);
-            if (testData == (data)) {
+
+            if(config.matchMethod == "Starts With") {
+                matched = data.startsWith(testData);
+            }
+
+            if(config.matchMethod == "Contains") {
+                matched = data.contains(testData);
+            }
+
+            if(config.matchMethod == "Ends With") {
+                matched = data.endsWith(testData);
+            }
+
+            if(config.matchMethod == "Exact Match") {
+                matched = (testData == (data));
+            }
+
+
+            if (matched) {
                 QDEBUG() << "Match! Sending:" << config.replyWith;
                 return Packet::encodingToByteArray(config.encoding, config.replyWith);
             }

--- a/src/packet.h
+++ b/src/packet.h
@@ -31,6 +31,7 @@ struct SmartResponseConfig {
     QString ifEquals;
     QString replyWith;
     QString encoding;
+    QString matchMethod;
     bool enabled;
 };
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -169,6 +169,14 @@ Settings::Settings(QWidget *parent, MainWindow* mw) :
     ENCODEMACRO(4);
     ENCODEMACRO(5);
 
+#define MATCHMACRO(NUM) ui->matchMethodBox##NUM->setCurrentIndex(ui->matchMethodBox##NUM->findText(settings.value("matchMethodBox"#NUM,"Exact Match").toString()))
+
+    MATCHMACRO(1);
+    MATCHMACRO(2);
+    MATCHMACRO(3);
+    MATCHMACRO(4);
+    MATCHMACRO(5);
+
 
     on_smartResponseEnableCheck_clicked();
 
@@ -586,6 +594,17 @@ void Settings::on_buttonBox_accepted()
     ENCODEMACROSAVE(3);
     ENCODEMACROSAVE(4);
     ENCODEMACROSAVE(5);
+
+
+#define MATCHMACROSAVE(NUM) settings.setValue("matchMethodBox" #NUM, ui->matchMethodBox##NUM->currentText());
+
+    MATCHMACROSAVE(1);
+    MATCHMACROSAVE(2);
+    MATCHMACROSAVE(3);
+    MATCHMACROSAVE(4);
+    MATCHMACROSAVE(5);
+
+
 
     if((initialSslLocalCertificatePath != settings.value("sslLocalCertificatePath", "").toString()) ||
         (initialSslCaPath != settings.value("sslCaPath", "").toString()) ||

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="settingsTabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tab_2">
       <attribute name="title">
@@ -780,15 +780,11 @@
           <string/>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_13">
-            <property name="text">
-             <string>Response 5</string>
-            </property>
-           </widget>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="responseIfEdit5"/>
           </item>
-          <item row="4" column="3">
-           <widget class="QComboBox" name="responseEncodingBox4">
+          <item row="3" column="4">
+           <widget class="QComboBox" name="responseEncodingBox3">
             <item>
              <property name="text">
               <string>Mixed ASCII</string>
@@ -801,55 +797,24 @@
             </item>
            </widget>
           </item>
-          <item row="4" column="4">
-           <widget class="QCheckBox" name="responseEnableCheck4">
+          <item row="4" column="3">
+           <widget class="QLineEdit" name="responseReplyEdit4"/>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string>Response 5</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="5">
+           <widget class="QCheckBox" name="responseEnableCheck2">
             <property name="text">
              <string>Enable</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_12">
-            <property name="text">
-             <string>Response 4</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>If Packet data equals</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Reply with</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Encoding</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Response 1</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="responseIfEdit1"/>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLineEdit" name="responseReplyEdit1"/>
-          </item>
-          <item row="1" column="3">
+          <item row="1" column="4">
            <widget class="QComboBox" name="responseEncodingBox1">
             <item>
              <property name="text">
@@ -863,18 +828,12 @@
             </item>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="responseIfEdit2"/>
-          </item>
-          <item row="1" column="4">
+          <item row="1" column="5">
            <widget class="QCheckBox" name="responseEnableCheck1">
             <property name="text">
              <string>Enable</string>
             </property>
            </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QLineEdit" name="responseReplyEdit2"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="label_10">
@@ -883,8 +842,21 @@
             </property>
            </widget>
           </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="responseIfEdit3"/>
+          </item>
+          <item row="5" column="5">
+           <widget class="QCheckBox" name="responseEnableCheck5">
+            <property name="text">
+             <string>Enable</string>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="3">
-           <widget class="QComboBox" name="responseEncodingBox2">
+           <widget class="QLineEdit" name="responseReplyEdit2"/>
+          </item>
+          <item row="5" column="4">
+           <widget class="QComboBox" name="responseEncodingBox5">
             <item>
              <property name="text">
               <string>Mixed ASCII</string>
@@ -897,6 +869,37 @@
             </item>
            </widget>
           </item>
+          <item row="4" column="5">
+           <widget class="QCheckBox" name="responseEnableCheck4">
+            <property name="text">
+             <string>Enable</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Search term</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Encoding</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Reply with</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="responseIfEdit1"/>
+          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="label_11">
             <property name="text">
@@ -904,28 +907,8 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="4">
-           <widget class="QCheckBox" name="responseEnableCheck2">
-            <property name="text">
-             <string>Enable</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QLineEdit" name="responseReplyEdit3"/>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLineEdit" name="responseIfEdit3"/>
-          </item>
-          <item row="3" column="4">
-           <widget class="QCheckBox" name="responseEnableCheck3">
-            <property name="text">
-             <string>Enable</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <widget class="QComboBox" name="responseEncodingBox3">
+          <item row="4" column="4">
+           <widget class="QComboBox" name="responseEncodingBox4">
             <item>
              <property name="text">
               <string>Mixed ASCII</string>
@@ -941,24 +924,14 @@
           <item row="4" column="1">
            <widget class="QLineEdit" name="responseIfEdit4"/>
           </item>
-          <item row="4" column="2">
-           <widget class="QLineEdit" name="responseReplyEdit4"/>
-          </item>
-          <item row="5" column="1">
-           <widget class="QLineEdit" name="responseIfEdit5"/>
-          </item>
-          <item row="5" column="2">
-           <widget class="QLineEdit" name="responseReplyEdit5"/>
-          </item>
-          <item row="5" column="4">
-           <widget class="QCheckBox" name="responseEnableCheck5">
-            <property name="text">
-             <string>Enable</string>
-            </property>
-           </widget>
+          <item row="1" column="3">
+           <widget class="QLineEdit" name="responseReplyEdit1"/>
           </item>
           <item row="5" column="3">
-           <widget class="QComboBox" name="responseEncodingBox5">
+           <widget class="QLineEdit" name="responseReplyEdit5"/>
+          </item>
+          <item row="2" column="4">
+           <widget class="QComboBox" name="responseEncodingBox2">
             <item>
              <property name="text">
               <string>Mixed ASCII</string>
@@ -967,6 +940,160 @@
             <item>
              <property name="text">
               <string>HEX</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Response 1</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="5">
+           <widget class="QCheckBox" name="responseEnableCheck3">
+            <property name="text">
+             <string>Enable</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QLineEdit" name="responseReplyEdit3"/>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Response 4</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="responseIfEdit2"/>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_23">
+            <property name="text">
+             <string>Search Method      </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QComboBox" name="matchMethodBox1">
+            <item>
+             <property name="text">
+              <string>Exact Match</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Contains</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Starts With</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ends With</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QComboBox" name="matchMethodBox2">
+            <item>
+             <property name="text">
+              <string>Exact Match</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Contains</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Starts With</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ends With</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QComboBox" name="matchMethodBox3">
+            <item>
+             <property name="text">
+              <string>Exact Match</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Contains</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Starts With</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ends With</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QComboBox" name="matchMethodBox4">
+            <item>
+             <property name="text">
+              <string>Exact Match</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Contains</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Starts With</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ends With</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QComboBox" name="matchMethodBox5">
+            <item>
+             <property name="text">
+              <string>Exact Match</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Contains</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Starts With</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ends With</string>
              </property>
             </item>
            </widget>


### PR DESCRIPTION

Adding support for partial matches, as requested by #332 .  

![image](https://github.com/user-attachments/assets/11d5f1ae-44a2-4805-950b-50d57cc3d6c4)


The default is Exact Match to prevent breaking updates. 