### PR TITLE
add unit tests (for translations)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,6 +156,17 @@ if(APPLE)
   )
 endif()
 
+# ==================== UNIT TESTS (QtTest) ====================
+option(PACKETSENDER_BUILD_TESTS "Build unit tests (QtTest)" OFF)
+
+if(PACKETSENDER_BUILD_TESTS)
+  find_package(Qt6 REQUIRED COMPONENTS Test)
+
+  enable_testing()
+
+  add_subdirectory(tests/unit)
+endif()
+
 # -------------------
 # Packaging
 # -------------------

--- a/src/tests/unit/CMakeLists.txt
+++ b/src/tests/unit/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Forced architecture" FORCE)
 
-set(TEST_NAME "translation_test")
+set(TEST_NAME "packetsender_unittests")
 
 add_executable(${TEST_NAME}
     translation_test.cpp

--- a/src/tests/unit/CMakeLists.txt
+++ b/src/tests/unit/CMakeLists.txt
@@ -1,0 +1,24 @@
+set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Forced architecture" FORCE)
+
+set(TEST_NAME "translation_test")
+
+add_executable(${TEST_NAME}
+    translation_test.cpp
+
+    ../../translations.h
+    ../../translations.cpp
+)
+
+target_include_directories(${TEST_NAME} PRIVATE
+    ${CMAKE_SOURCE_DIR}             # so #include "translations.h" works cleanly
+)
+
+target_link_libraries(${TEST_NAME} PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Widgets                    # needed because installLanguage uses QApplication
+    Qt6::Test
+)
+
+# Make ctest run it
+add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})

--- a/src/tests/unit/translation_test.cpp
+++ b/src/tests/unit/translation_test.cpp
@@ -1,0 +1,40 @@
+//
+// Created by Tomas Gallucci on 3/2/26.
+//
+
+#include <QtTest/QtTest>
+#include "translations.h"
+
+class TranslationTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testInstallLanguage_data()
+    {
+        QTest::addColumn<QString>("language");
+        QTest::addColumn<bool>("expected");
+
+        QTest::newRow("empty → system default")     << ""         << true;
+        QTest::newRow("unsupported")                << "Klingon" << false;
+        QTest::newRow("Spanish (supported)")        << "Spanish"  << true;
+        QTest::newRow("German (supported)")         << "German"   << true;
+        QTest::newRow("French (supported)")         << "French"   << true;
+        QTest::newRow("Italian (supported)")        << "Italian"  << true;
+        QTest::newRow("Chinese (supported)")        << "Chinese"  << true;
+    }
+
+    void testInstallLanguage()
+    {
+        QFETCH(QString, language);
+        QFETCH(bool, expected);
+
+        // This exercises both loadAndInstallTranslators() and the map lookup
+        bool result = Translations::installLanguage(language);
+
+        QCOMPARE(result, expected);
+    }
+};
+
+QTEST_MAIN(TranslationTest)
+#include "translation_test.moc"


### PR DESCRIPTION
Before submitting a pull request:

- Did you fork from the development branch? yes
- Are you submitting the pull request to the development branch? (not master) yes


---

This Pull Request adds some QtUnit unit tests to the project.

I thought it would be a good idea to add unit tests and wanted to test something that was fairly isolated. It turns out, I already provided the necessary isolation with code I added recently which is why I chose to unit test the translation.

As submitted, this PR only builds the unit test (singular because there's only one test even if it is parallelized) via CMake. `qmake` can be used and allegedly I have instructions on how to get the tests building with `qmake`. But this might be the necessary motivation to get off of `qmake` everywhere we are still running `qmake` builds and full get on CMake.

**NOTE**: this PR does not provide ci configuration to run the tests as part of the build.

I tested this code on macOS Tahoe 26.3 on an M2 MacBook Pro; all bets are off other places, say SnapCraft.