### PR TITLE
Support HTTP/S PUT, PATCH and DELETE

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -19,7 +19,7 @@ jobs:
     - name: install_dependencies
       run: |
            sudo apt update
-           sudo apt install cmake debhelper devscripts qt6-base-dev qt6-base-dev-tools build-essential
+           sudo apt install cmake debhelper devscripts qt6-base-dev qt6-base-dev-tools qt6-tools-dev build-essential
     - name: build
       run: |
            debuild --no-lintian --no-sign

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Downloads](https://img.shields.io/github/downloads/dannagle/PacketSender/total.svg)](https://packetsender.com/download)
 
-Packet Sender is an open source utility to allow sending and receiving TCP, UDP, and SSL (encrypted TCP) packets as well as HTTP/HTTPS requests and panel generation. The mainline branch officially supports Windows, Mac, and Desktop Linux (with Qt). Other places may recompile and redistribute Packet Sender. Packet Sender is free and licensed GPL v2 or later. It can be used for both commercial and personal use. If you find the app useful, please consider donating/sponsoring so development may continue.
+Packet Sender is an open source utility to allow sending and receiving TCP, UDP, and SSL (encrypted TCP) packets as well as HTTP/HTTPS requests (GET, POST, PUT, PATCH, and DELETE) and panel generation. The mainline branch officially supports Windows, Mac, and Desktop Linux (with Qt). Other places may recompile and redistribute Packet Sender. Packet Sender is free and licensed GPL v2 or later. It can be used for both commercial and personal use. If you find the app useful, please consider donating/sponsoring so development may continue.
 
 
 
@@ -381,11 +381,28 @@ Persistent connections are not supported via the command line.
 
 
 <a id="http"></a>
-# HTTP/HTTPS POST & GET
-Packet Sender supports sending POST/GET requests via HTTP and HTTPS. 
-Protocol dropdown includes the following options: HTTP GET, HTTP POST, HTTPS GET, HTTPS POST. When selecting HTTP(S), input fields will update to: Name, Request, Address, Data (when POST is selected), Generate Data button (when POST is selected), Load File (when POST is selected). 
+### HTTP/HTTPS Requests
 
-## Sending HTTP/HTTPS GET/POST Requests
+Packet Sender includes a clean, user-friendly interface for making HTTP and HTTPS requests. You can easily:
+
+- Choose from **GET, POST, PUT, PATCH, DELETE**
+- Set custom request paths
+- Send JSON, form data, or raw bodies
+- View full response headers and body
+
+#### Supported Methods
+
+| Method  | Use Case                        | Body Supported |
+|---------|---------------------------------|----------------|
+| GET     | Retrieve data                   | No             |
+| POST    | Create / submit data            | Yes            |
+| PUT     | Replace entire resource         | Yes            |
+| PATCH   | Partial update of a resource    | Yes            |
+| DELETE  | Delete a resource               | Optional       |
+
+**PATCH** is particularly useful for sending partial updates using `application/json` or `application/json-patch+json`. 
+
+## Sending HTTP/HTTPS GET/POST/PUT/PATCH/DELETE Requests
 ![](/screenshots/ps_http_getfields.PNG)
 * Select HTTP(S) GET or POST from the protocol dropdown
 * In *Address* field input the domain or IP
@@ -395,7 +412,7 @@ Protocol dropdown includes the following options: HTTP GET, HTTP POST, HTTPS GET
 
 **You may also paste a complete URL in the Request field and Packet Sender will parse and auto-populate the other fields.**
 
-### For POST Requests:
+### For POST/PUT/PATCH/DELETE Requests:
 * You can manually add in the data into the *Data* field.
 	* Format would go: key=value
 	* For multiple parameters: key=value&key=value&key=value

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Qt6 REQUIRED COMPONENTS
     Gui
     Network
     Widgets
+    LinguistTools
 )
 
 set(
@@ -88,6 +89,17 @@ set(
   dtlsserver.cpp
   dtlsthread.cpp
 )
+
+qt_add_translations(PacketSender
+    TS_FILES
+    languages/packetsender_de.ts
+    languages/packetsender_fr.ts
+    languages/packetsender_hi.ts
+    languages/packetsender_en.ts
+    languages/packetsender_es.ts
+    languages/packetsender_it.ts
+    languages/packetsender_cn.ts
+  )
 
 set(
   PACKETSENDER_QRC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,16 +90,6 @@ set(
   dtlsthread.cpp
 )
 
-qt_add_translations(PacketSender
-    TS_FILES
-    languages/packetsender_de.ts
-    languages/packetsender_fr.ts
-    languages/packetsender_hi.ts
-    languages/packetsender_en.ts
-    languages/packetsender_es.ts
-    languages/packetsender_it.ts
-    languages/packetsender_cn.ts
-  )
 
 set(
   PACKETSENDER_QRC
@@ -142,6 +132,18 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   Qt6::Network
   Qt6::Widgets
 )
+
+
+qt_add_translations(${PROJECT_NAME}
+    TS_FILES
+    languages/packetsender_de.ts
+    languages/packetsender_fr.ts
+    languages/packetsender_hi.ts
+    languages/packetsender_en.ts
+    languages/packetsender_es.ts
+    languages/packetsender_it.ts
+    languages/packetsender_cn.ts
+  )
 
 set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "Build architectures for Mac OS X" FORCE)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -650,7 +650,7 @@ int main(int argc, char *argv[])
 
         if(http) {
             if(parser.isSet(httpOption)) {
-                qDebug() << "Before replace - tcpOrUdp =" << sendPacket.tcpOrUdp;
+                QDEBUG() << "Before replace - tcpOrUdp =" << sendPacket.tcpOrUdp;
 
                 // Key = uppercase (for comparison), Value = Title Case (for display)
                 static const QMap<QString, QString> validMethods = {
@@ -688,7 +688,7 @@ int main(int argc, char *argv[])
                 }
 
                 sendPacket.setHttpMethod(httpMethod, address);
-                qDebug() << "After calling sendPacket.setHttpMethod - tcpOrUdp =" << sendPacket.tcpOrUdp;
+                QDEBUG() << "After calling sendPacket.setHttpMethod - tcpOrUdp =" << sendPacket.tcpOrUdp;
             }
         } else {
             if (argssize >= 2) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -592,26 +592,31 @@ int main(int argc, char *argv[])
 
 
         QString name = parser.value(nameOption);
-
-        QString httpMethod = parser.value(httpOption).trimmed().toUpper();
-
-
-
+        const QString httpMethod = parser.value(httpOption).trimmed().toUpper();
         QString filePath = parser.value(fileOption);
-
-
         QString address = "";
         QString addressOriginal = "";
         unsigned int port = 0;
 
         int argssize = args.size();
         QDEBUGVAR(argssize);
+
         QString data, dataString;
         data.clear();
         dataString.clear();
         if (argssize >= 1) {
             address = args[0];
         }
+
+        auto exitWithError = [&](const QString &message = QString()) {
+            if (!message.isEmpty()) {
+                OUTIF() << message;
+            }
+
+            filePath.clear();
+            OUTPUT();
+            exit(-1);
+        };
 
 
         if(wol) {
@@ -645,35 +650,46 @@ int main(int argc, char *argv[])
 
         if(http) {
             if(parser.isSet(httpOption)) {
-                if(httpMethod != "GET" && httpMethod != "POST") {
-                    OUTIF() << "Error: supported HTTP methods are GET and POST. Specified: " << httpMethod;
-                    filePath.clear();
-                    OUTPUT();
-                    return -1;
+                qDebug() << "Before replace - tcpOrUdp =" << sendPacket.tcpOrUdp;
+
+                // Key = uppercase (for comparison), Value = Title Case (for display)
+                static const QMap<QString, QString> validMethods = {
+                    {"GET",    "Get"},
+                    {"POST",   "Post"},
+                    {"PUT",    "Put"},
+                    {"DELETE", "Delete"},
+                    {"PATCH",  "Patch"}
+                };
+
+                if(!validMethods.contains(httpMethod)) {
+                    OUTIF() << "Error: supported HTTP methods are GET, POST, PUT, DELETE, PATCH.";
+                    OUTIF() << "You specified: " << httpMethod;
+                    exitWithError();
                 }
 
-                if(name.isEmpty()) {
-                    if(address.isEmpty()) {
-                        OUTIF() << "Error: URL is required after HTTP method is no name is supplied.";
-                        filePath.clear();
-                        OUTPUT();
-                        return -1;
-                    }
+                if(name.isEmpty() && address.isEmpty()) {
+                    OUTIF() << "Error: URL is required after HTTP method if no name is supplied.";
+                    exitWithError();
                 }
 
-                if(httpMethod == "POST") {
+                // Only these methods require a body
+                static const QSet<QString> methodsRequiringBody = {"POST", "PUT", "PATCH"};
+
+                if(methodsRequiringBody.contains(httpMethod)) {
                     if(argssize < 2) {
-                        OUTIF() << "Error: data is required after specifying POST.";
-                        filePath.clear();
-                        OUTPUT();
-                        return -1;
+                        OUTIF() << "Error: data is required after specifying " << httpMethod;
+                        exitWithError();
                     } else {
                         data = args[1];
                     }
                 }
+                else if (httpMethod == "DELETE" && argssize >= 2) {
+                    data = args[1];        // optional body
+                }
 
+                sendPacket.setHttpMethod(httpMethod, address);
+                qDebug() << "After calling sendPacket.setHttpMethod - tcpOrUdp =" << sendPacket.tcpOrUdp;
             }
-
         } else {
             if (argssize >= 2) {
                 port = args[1].toUInt();
@@ -1069,17 +1085,20 @@ int main(int argc, char *argv[])
         // Test packet 1:  .\packetsender.com --name "HTTPS POST Params"
         // Test packet 2: .\packetsender.com --http GET "https://httpbin.org/get"
         // Test packet 3: .\packetsender.com --http POST "https://httpbin.org/post" "{""hello"":1}"
+        // Test packet 4: .\packetsender.com --http PUT "http://httpbin.org/put" "test put body"
+        // Test packet 5: .\packetsender.com --http PUT "http://httpbin.org/put" '{"name": "test", "value": 123}'
+        // Test packet 6: .\packetsender.com --http PUT "https://httpbin.org/put" "secure put data"
+        // Test packet 7: .\packetsender.com --http PATCH "http://httpbin.org/patch" "test patch body"
+        // Test packet 8: .\packetsender.com --http PATCH "http://httpbin.org/patch" '{"updated": true, "status": "active"}'
+        // Test packet 9: .\packetsender.com --http PATCH "https://httpbin.org/patch" "secure patch data"
+        // Test packet 10: .\packetsender.com --http DELETE "http://httpbin.org/delete"
+        // Test packet 11: .\packetsender.com --http DELETE "https://httpbin.org/delete"
 
         if(http) {            
             if ((!address.isEmpty()) && address.contains("://")) {
                 sendPacket.requestPath = Packet::getRequestFromURL(address);
-                sendPacket.tcpOrUdp = Packet::getMethodFromURL(address);
                 sendPacket.port = Packet::getPortFromURL(address);
                 sendPacket.toIP = Packet::getHostFromURL(address);
-            }
-
-            if(httpMethod.contains("POST")) {
-                sendPacket.tcpOrUdp.replace("Get", "Post");
             }
 
             sendPacket.persistent = false;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1583,6 +1583,7 @@ void MainWindow::on_packetsTable_itemChanged(QTableWidgetItem *item)
         bool isHTTP  = upperText.contains("HTTP") ||
                        upperText.contains("GET")  ||
                        upperText.contains("POST") ||
+                       upperText.contains("PUT") ||
                        upperText.contains("DELETE");
 
         if (isHTTP) {
@@ -1591,6 +1592,7 @@ void MainWindow::on_packetsTable_itemChanged(QTableWidgetItem *item)
             // Normalize the method
             QString method = "GET";  // default
             if (upperText.contains("POST"))        method = "POST";
+            else if (upperText.contains("PUT"))    method = "PUT";
             else if (upperText.contains("DELETE")) method = "DELETE";
 
             updatePacket.tcpOrUdp = isHTTPS ? "HTTPS" : "HTTP";
@@ -2752,10 +2754,15 @@ void MainWindow::on_udptcpComboBox_currentIndexChanged(const QString &arg1)
         ui->packetPortEdit->setText("80");
     }
 
-    const auto isPost = selectedText.contains("post") && isHttp;
-    const auto isDelete = selectedText.contains("delete") && isHttp;
+    const auto isGet    = selectedText.contains("get");
+    const auto isPost   = selectedText.contains("post");
+    const auto isPut    = selectedText.contains("put");
+    const auto isDelete = selectedText.contains("delete");
 
-    const bool shouldShowDataField = isPost || isDelete;
+    const bool shouldShowDataField = isPost || isPut || isDelete;
+
+    // Use nice HTTP UI for GET/POST/PUT/DELETE on both http and https
+    const bool isNiceHttpProtocol = (isHttp || isHttps) && (isGet || isPost || isPut || isDelete);
 
     /////////////////////////////////dtls add line edit for adding path for cert
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2779,25 +2779,27 @@ void MainWindow::on_udptcpComboBox_currentIndexChanged(const QString &arg1)
         ui->asciiLabel->setText("ASCII");
     }
 
-
+    // Hide HEX for nice HTTP(S) protocols
     for (int i = 0; i < ui->hexHorizLayout->count(); ++i) {
         QWidget *w = ui->hexHorizLayout->itemAt(i)->widget();
-        if(w != nullptr) {
-            w->setVisible(!isHttp);
+        if (w != nullptr) {
+            w->setVisible(!isNiceHttpProtocol);
         }
     }
 
+    // Show Request field for nice HTTP(S) protocols
     for (int i = 0; i < ui->requestLayout->count(); ++i) {
         QWidget *w = ui->requestLayout->itemAt(i)->widget();
-        if(w != nullptr) {
-            w->setVisible(isHttp);
+        if (w != nullptr) {
+            w->setVisible(isNiceHttpProtocol);
         }
     }
 
+    // Show ASCII/Data field for raw modes OR when we have POST/PUT/DELETE
     for (int i = 0; i < ui->asciiLayout->count(); ++i) {
         QWidget *w = ui->asciiLayout->itemAt(i)->widget();
-        if(w != nullptr) {
-            w->setVisible((!isHttp) || shouldShowDataField);
+        if (w != nullptr) {
+            w->setVisible(!isNiceHttpProtocol || shouldShowDataField);
         }
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2742,6 +2742,16 @@ void MainWindow::on_udptcpComboBox_currentIndexChanged(const QString &arg1)
 
     const auto isHttps = selectedText.contains("https");
     const auto isHttp  = selectedText.contains("http") && !isHttps;
+
+    // === Smart port defaulting ===
+    int currentPort = ui->packetPortEdit->text().trimmed().toInt();
+
+    if (isHttps && (currentPort == 80 || currentPort == 0)) {
+        ui->packetPortEdit->setText("443");
+    } else if (isHttp && (currentPort == 443 || currentPort == 0)) {
+        ui->packetPortEdit->setText("80");
+    }
+
     const auto isPost = selectedText.contains("post") && isHttp;
     const auto isDelete = selectedText.contains("delete") && isHttp;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1584,6 +1584,7 @@ void MainWindow::on_packetsTable_itemChanged(QTableWidgetItem *item)
                        upperText.contains("GET")  ||
                        upperText.contains("POST") ||
                        upperText.contains("PUT") ||
+                       upperText.contains("PATCH") ||
                        upperText.contains("DELETE");
 
         if (isHTTP) {
@@ -1594,6 +1595,7 @@ void MainWindow::on_packetsTable_itemChanged(QTableWidgetItem *item)
             if (upperText.contains("POST"))        method = "POST";
             else if (upperText.contains("PUT"))    method = "PUT";
             else if (upperText.contains("DELETE")) method = "DELETE";
+            else if (upperText.contains("PATCH"))  method = "PATCH";
 
             updatePacket.tcpOrUdp = isHTTPS ? "HTTPS" : "HTTP";
             updatePacket.tcpOrUdp.append(" " + method);
@@ -2757,12 +2759,13 @@ void MainWindow::on_udptcpComboBox_currentIndexChanged(const QString &arg1)
     const auto isGet    = selectedText.contains("get");
     const auto isPost   = selectedText.contains("post");
     const auto isPut    = selectedText.contains("put");
+    const auto isPatch  = selectedText.contains("patch");
     const auto isDelete = selectedText.contains("delete");
 
-    const bool shouldShowDataField = isPost || isPut || isDelete;
+    const bool shouldShowDataField = isPost || isPut || isPatch || isDelete;
 
-    // Use nice HTTP UI for GET/POST/PUT/DELETE on both http and https
-    const bool isNiceHttpProtocol = (isHttp || isHttps) && (isGet || isPost || isPut || isDelete);
+    // Use nice HTTP UI for GET/POST/PUT/PATCH/DELETE on both http and https
+    const bool isNiceHttpProtocol = (isHttp || isHttps) && (isGet || isPost || isPut || isPatch || isDelete);
 
     /////////////////////////////////dtls add line edit for adding path for cert
 
@@ -2795,7 +2798,7 @@ void MainWindow::on_udptcpComboBox_currentIndexChanged(const QString &arg1)
         }
     }
 
-    // Show ASCII/Data field for raw modes OR when we have POST/PUT/DELETE
+    // Show ASCII/Data field for raw modes OR when we have POST/PUT/PATCH/DELETE
     for (int i = 0; i < ui->asciiLayout->count(); ++i) {
         QWidget *w = ui->asciiLayout->itemAt(i)->widget();
         if (w != nullptr) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1573,27 +1573,31 @@ void MainWindow::on_packetsTable_itemChanged(QTableWidgetItem *item)
         updatePacket.repeat = repeat;
     }
     if (datatype == Settings::METHOD_STR) {
-        if ((newText.trimmed().toUpper() == "TCP") || (newText.trimmed().toUpper() == "UDP") || (newText.trimmed().toUpper() == "SSL")) {
-            updatePacket.tcpOrUdp = newText.trimmed().toUpper();
-        }
-        auto isHTTP = newText.trimmed().toUpper().contains("HTTP") || newText.trimmed().toUpper().contains("GET") || newText.trimmed().toUpper().contains("POST");
+        QString upperText = newText.trimmed().toUpper();
 
-        if(isHTTP) {
-            auto isHTTPS = (newText.trimmed().toUpper().contains("HTTPS"));
-            auto isPOST = newText.trimmed().toUpper().contains("POST");
-            updatePacket.tcpOrUdp = "HTTP";
-            if(isHTTPS) {
-                updatePacket.tcpOrUdp.append("S");
-            }
-            if(isPOST) {
-                updatePacket.tcpOrUdp.append(" Post");
-            } else {
-                updatePacket.tcpOrUdp.append(" Get");
-            }
+        if (upperText == "TCP" || upperText == "UDP" || upperText == "SSL") {
+            updatePacket.tcpOrUdp = upperText;
+            return;  // early exit for non-HTTP
         }
 
+        bool isHTTP  = upperText.contains("HTTP") ||
+                       upperText.contains("GET")  ||
+                       upperText.contains("POST") ||
+                       upperText.contains("DELETE");
 
+        if (isHTTP) {
+            bool isHTTPS = upperText.contains("HTTPS");
+
+            // Normalize the method
+            QString method = "GET";  // default
+            if (upperText.contains("POST"))        method = "POST";
+            else if (upperText.contains("DELETE")) method = "DELETE";
+
+            updatePacket.tcpOrUdp = isHTTPS ? "HTTPS" : "HTTP";
+            updatePacket.tcpOrUdp.append(" " + method);
+        }
     }
+
     if (datatype == Settings::ASCII_STR) {
         QString hex = Packet::ASCIITohex(newText);
         updatePacket.hexString = hex;
@@ -2732,10 +2736,16 @@ void MainWindow::on_actionDonate_Thank_You_triggered()
 
 void MainWindow::on_udptcpComboBox_currentIndexChanged(const QString &arg1)
 {
+    Q_UNUSED(arg1)
 
-    QString selectedText = ui->udptcpComboBox->currentText().toLower();
-    auto isHttp = selectedText.contains("http");
-    auto isPost = selectedText.contains("post") && isHttp;
+    const QString selectedText = ui->udptcpComboBox->currentText().toLower();
+
+    const auto isHttps = selectedText.contains("https");
+    const auto isHttp  = selectedText.contains("http") && !isHttps;
+    const auto isPost = selectedText.contains("post") && isHttp;
+    const auto isDelete = selectedText.contains("delete") && isHttp;
+
+    const bool shouldShowDataField = isPost || isDelete;
 
     /////////////////////////////////dtls add line edit for adding path for cert
 
@@ -2770,11 +2780,11 @@ void MainWindow::on_udptcpComboBox_currentIndexChanged(const QString &arg1)
     for (int i = 0; i < ui->asciiLayout->count(); ++i) {
         QWidget *w = ui->asciiLayout->itemAt(i)->widget();
         if(w != nullptr) {
-            w->setVisible((!isHttp) || isPost);
+            w->setVisible((!isHttp) || shouldShowDataField);
         }
     }
 
-    ui->genPostDataButton->setVisible(isPost);
+    ui->genPostDataButton->setVisible(shouldShowDataField);
 }
 
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -278,6 +278,15 @@
              </item>
              <item>
               <property name="text">
+               <string>HTTP Delete</string>
+              </property>
+              <property name="icon">
+               <iconset resource="packetsender.qrc">
+                <normaloff>:/icons/tx_http.png</normaloff>:/icons/tx_http.png</iconset>
+              </property>
+             </item>
+             <item>
+              <property name="text">
                <string>HTTPS Get</string>
               </property>
               <property name="icon">
@@ -288,6 +297,15 @@
              <item>
               <property name="text">
                <string>HTTPS Post</string>
+              </property>
+              <property name="icon">
+               <iconset resource="packetsender.qrc">
+                <normaloff>:/icons/tx_http.png</normaloff>:/icons/tx_http.png</iconset>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>HTTPS Delete</string>
               </property>
               <property name="icon">
                <iconset resource="packetsender.qrc">
@@ -699,7 +717,7 @@
      <x>0</x>
      <y>0</y>
      <width>909</width>
-     <height>21</height>
+     <height>33</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -278,6 +278,15 @@
              </item>
              <item>
               <property name="text">
+               <string>HTTP Put</string>
+              </property>
+              <property name="icon">
+               <iconset resource="packetsender.qrc">
+                <normaloff>:/icons/tx_http.png</normaloff>:/icons/tx_http.png</iconset>
+              </property>
+             </item>
+             <item>
+              <property name="text">
                <string>HTTP Delete</string>
               </property>
               <property name="icon">
@@ -297,6 +306,15 @@
              <item>
               <property name="text">
                <string>HTTPS Post</string>
+              </property>
+              <property name="icon">
+               <iconset resource="packetsender.qrc">
+                <normaloff>:/icons/tx_http.png</normaloff>:/icons/tx_http.png</iconset>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>HTTPS Put</string>
               </property>
               <property name="icon">
                <iconset resource="packetsender.qrc">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -287,6 +287,15 @@
              </item>
              <item>
               <property name="text">
+               <string>HTTP Patch</string>
+              </property>
+              <property name="icon">
+               <iconset resource="packetsender.qrc">
+                <normaloff>:/icons/tx_http.png</normaloff>:/icons/tx_http.png</iconset>
+              </property>
+             </item>
+             <item>
+              <property name="text">
                <string>HTTP Delete</string>
               </property>
               <property name="icon">
@@ -315,6 +324,15 @@
              <item>
               <property name="text">
                <string>HTTPS Put</string>
+              </property>
+              <property name="icon">
+               <iconset resource="packetsender.qrc">
+                <normaloff>:/icons/tx_http.png</normaloff>:/icons/tx_http.png</iconset>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>HTTPS Patch</string>
               </property>
               <property name="icon">
                <iconset resource="packetsender.qrc">

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -93,6 +93,9 @@ bool Packet::isPOST()
     return  isHTTP() && ((tcpOrUdp.trimmed().toLower().contains("post")));
 }
 
+bool Packet::isPUT() {
+    return isHTTP() && tcpOrUdp.trimmed().toLower().contains("put");
+}
 
 bool Packet::isDELETE() {
     return isHTTP() && (tcpOrUdp.trimmed().toLower().contains("delete"));

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -82,15 +82,15 @@ bool Packet::isUDP()
 
 bool Packet::isHTTP()
 {
-    return ((tcpOrUdp.trimmed().toLower().contains("http")));
+    return tcpOrUdp.trimmed().toLower().contains("http");
 }
 bool Packet::isHTTPS()
 {
-    return ((tcpOrUdp.trimmed().toLower().contains("https")));
+    return tcpOrUdp.trimmed().toLower().contains("https");
 }
 bool Packet::isPOST()
 {
-    return  isHTTP() && ((tcpOrUdp.trimmed().toLower().contains("post")));
+    return  isHTTP() && tcpOrUdp.trimmed().toLower().contains("post");
 }
 
 bool Packet::isPUT() {
@@ -98,7 +98,8 @@ bool Packet::isPUT() {
 }
 
 bool Packet::isDELETE() {
-    return isHTTP() && (tcpOrUdp.trimmed().toLower().contains("delete"));
+    return isHTTP() && tcpOrUdp.trimmed().toLower().contains("delete");
+}
 
 bool Packet::isPATCH() {
     return isHTTP() && tcpOrUdp.trimmed().toLower().contains("patch");
@@ -106,7 +107,7 @@ bool Packet::isPATCH() {
 
 bool Packet::isTCP()
 {
-    return ((tcpOrUdp.trimmed().toLower().contains("tcp") || isSSL()));
+    return tcpOrUdp.trimmed().toLower().contains("tcp") || isSSL();
 }
 
 float Packet::oneDecimal(float value)

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -93,6 +93,11 @@ bool Packet::isPOST()
     return  isHTTP() && ((tcpOrUdp.trimmed().toLower().contains("post")));
 }
 
+
+bool Packet::isDELETE() {
+    return isHTTP() && (tcpOrUdp.trimmed().toLower().contains("delete"));
+}
+
 bool Packet::isTCP()
 {
     return ((tcpOrUdp.trimmed().toLower().contains("tcp") || isSSL()));

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -99,6 +99,9 @@ bool Packet::isPUT() {
 
 bool Packet::isDELETE() {
     return isHTTP() && (tcpOrUdp.trimmed().toLower().contains("delete"));
+
+bool Packet::isPATCH() {
+    return isHTTP() && tcpOrUdp.trimmed().toLower().contains("patch");
 }
 
 bool Packet::isTCP()

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -629,6 +629,33 @@ void Packet::saveToDB()
 
 }
 
+void Packet::setHttpMethod(const QString& method, const QString& url)
+{
+    QString upper = method.trimmed().toUpper();
+
+    // Determine protocol (prefer url if available, fallback to current state)
+    QString protocol = "HTTP";
+    if (!url.isEmpty()) {
+        if (url.startsWith("https://", Qt::CaseInsensitive)) {
+            protocol = "HTTPS";
+        }
+    } else if (tcpOrUdp.contains("HTTPS", Qt::CaseInsensitive)) {
+        protocol = "HTTPS";
+    }
+
+    // Determine display method name
+    QString displayMethod;
+    if (upper == "GET") {
+        displayMethod = "Get";
+    } else {
+        displayMethod = upper[0].toUpper() + upper.mid(1).toLower();
+    }
+
+    tcpOrUdp = protocol + " " + displayMethod;
+
+    QDEBUG() << "Packet::setHttpMethod() ->" << tcpOrUdp;
+}
+
 Packet Packet::generateWakeOnLAN(QString &mac, int port)
 {
     /*

--- a/src/packet.h
+++ b/src/packet.h
@@ -89,6 +89,7 @@ class Packet
         QString asciiString();
 
         void saveToDB();
+        void setHttpMethod(const QString &method, const QString &url = QString());
 
         static Packet generateWakeOnLAN(QString &mac, int port);
 

--- a/src/packet.h
+++ b/src/packet.h
@@ -70,6 +70,7 @@ class Packet
         bool isHTTP();
         bool isHTTPS();
         bool isPOST();
+        bool isDELETE();
 
         QDateTime timestamp;
 

--- a/src/packet.h
+++ b/src/packet.h
@@ -70,7 +70,9 @@ class Packet
         bool isHTTP();
         bool isHTTPS();
         bool isPOST();
+        bool isPUT();
         bool isDELETE();
+        bool isPATCH();
 
         QDateTime timestamp;
 

--- a/src/packetnetwork.cpp
+++ b/src/packetnetwork.cpp
@@ -1153,7 +1153,14 @@ void PacketNetwork::packetToSend(Packet sendpacket)
             QDEBUG() << "http post request";
             http->post(request, sendpacket.getByteArray());
 
-        } else {
+        } else if (sendpacket.isDELETE()) {
+            if (bytes.isEmpty()) {
+                http->deleteResource(request);
+            } else {
+                http->sendCustomRequest(request, "DELETE", bytes );
+            }
+        } else
+        {
             QDEBUG() << "http get request";
             http->get(request);
         }

--- a/src/packetnetwork.cpp
+++ b/src/packetnetwork.cpp
@@ -1153,6 +1153,8 @@ void PacketNetwork::packetToSend(Packet sendpacket)
             QDEBUG() << "http post request";
             http->post(request, sendpacket.getByteArray());
 
+        } else if (sendpacket.isPUT()) {
+            http->put(request, bytes);
         } else if (sendpacket.isDELETE()) {
             if (bytes.isEmpty()) {
                 http->deleteResource(request);

--- a/src/packetnetwork.cpp
+++ b/src/packetnetwork.cpp
@@ -1155,6 +1155,8 @@ void PacketNetwork::packetToSend(Packet sendpacket)
 
         } else if (sendpacket.isPUT()) {
             http->put(request, bytes);
+        } else if (sendpacket.isPATCH()) {
+            http->sendCustomRequest(request, "PATCH", bytes);
         } else if (sendpacket.isDELETE()) {
             if (bytes.isEmpty()) {
                 http->deleteResource(request);

--- a/src/starter_set.json
+++ b/src/starter_set.json
@@ -376,5 +376,44 @@
         "sendresponse": "0",
         "tcporudp": "UDP",
         "toip": "1.1.1.1"
+    },
+    {
+        "name": "HTTPBin PUT Test",
+        "tcporudp": "HTTPS Put",
+        "toip": "httpbin.org",
+        "port": "443",
+        "requestpath": "/put",
+        "asciistring": "ewogICJuYW1lIjogIlBhY2tldFNlbmRlciIsCiAgIm1ldGhvZCI6ICJQVVQgdGVzdCIKfQ==",
+        "hexstring": "",
+        "repeat": 0,
+        "persist": 0,
+        "sendresponse": "0",
+        "receiveBeforeSend": "0"
+    },
+    {
+        "name": "HTTPBin PATCH Test",
+        "tcporudp": "HTTPS Patch",
+        "toip": "httpbin.org",
+        "port": "443",
+        "requestpath": "/patch",
+        "asciistring": "ewogICJzdGF0dXMiOiAidXBkYXRlZCIsCiAgInVwZGF0ZWRfYnkiOiAiUGFja2V0U2VuZGVyIgp9",
+        "hexstring": "",
+        "repeat": 0,
+        "persist": 0,
+        "sendresponse": "0",
+        "receiveBeforeSend": "0"
+    },
+    {
+        "name": "HTTPBin DELETE Test",
+        "tcporudp": "HTTPS Delete",
+        "toip": "httpbin.org",
+        "port": "443",
+        "requestpath": "/delete",
+        "asciistring": "",
+        "hexstring": "",
+        "repeat": 0,
+        "persist": 0,
+        "sendresponse": "0",
+        "receiveBeforeSend": "0"
     }
 ]


### PR DESCRIPTION
Before submitting a pull request:

- Did you fork from the development branch? yes
- Are you submitting the pull request to the development branch? (not master) yes

######


### Support HTTP/HTTPS PUT, PATCH, and DELETE methods

This PR adds full support for **PUT**, **PATCH**, and **DELETE** HTTP/HTTPS methods in Packet Sender.

#### ✨ Changes

- Added **HTTP Put**, **HTTPS Put**, **HTTP Patch**, **HTTPS Patch**, **HTTP Delete**, and **HTTPS Delete** options to the protocol dropdown.
- All HTTP/HTTPS methods now use the **clean UI** (Request field visible + ASCII body, HEX field hidden).
- Proper smart port defaulting (80 for HTTP, 443 for HTTPS).
- Implemented correct backend handling:
  - `QNetworkAccessManager::put()` for PUT
  - `sendCustomRequest("PATCH", ...)` for PATCH
  - `deleteResource()` for DELETE
- Improved and cleaned up method detection logic (`isPUT()`, `isPATCH()`, `isDELETE()`, etc.).
- Updated and expanded the **README.md** with a supported methods table and clearer documentation.

#### Why it matters
Users can now comfortably send PUT, PATCH, and DELETE requests with the same polished experience as GET and POST — no more falling back to raw HEX mode.

Closes #340