### PR TITLE
Reenable panel export

### DIFF
--- a/src/panelgenerator.cpp
+++ b/src/panelgenerator.cpp
@@ -59,12 +59,6 @@ PanelGenerator::PanelGenerator(QWidget *parent) :
 
     packetNetwork = nullptr;
 
-
-
-    // not working... not sure if ever will work
-    ui->menuExport->deleteLater();
-
-
 #ifdef RENDER_ONLY
     QDEBUG() << " panel RENDER_ONLY mode";
 #else

--- a/src/panelgenerator.cpp
+++ b/src/panelgenerator.cpp
@@ -110,7 +110,6 @@ PanelGenerator::PanelGenerator(QWidget *parent) :
     //remove menu options.
     ui->menuLoad->deleteLater();
     ui->menuSettings->deleteLater();
-    ui->menuExport->deleteLater();
 
 #endif
 

--- a/src/panelgenerator.cpp
+++ b/src/panelgenerator.cpp
@@ -178,7 +178,9 @@ PanelGenerator::PanelGenerator(QWidget *parent) :
 
     renderEditMode();
 
-
+    ui->actionWin_Package->setVisible(false);
+    ui->actionLinux_Package->setVisible(false);
+    ui->actionMac_Package->setVisible(false);
 
 }
 


### PR DESCRIPTION
Before submitting a pull request:

- Did you fork from the development branch? yes
- Are you submitting the pull request to the development branch? (not master) yes

---

**Description**: Re-enabled the Export menu options for panels (which had been disabled in a previous change).

* Restored visibility of the Export menu in PanelGenerator
* Added code to hide the three "Portable Executable" options (as they are not needed for most users)

This brings back the expected export functionality while keeping the UI clean.

---

Potentially closes #316 (I suspect Dan will want to keep that Issue open because PacketSender doesn't currently support a unified export. Given that settings and packets can also be exported, it would be a bit of a lift to add that feature, not because exporting is hard, but because importing the export has a lot of edge cases e.g do you overwrite? Do you merge? Allow the user a choice?)

Fixes #302 