### PR TITLE
add `QUERY` HTTP verb

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1216,6 +1216,30 @@ void MainWindow::saveSession(Packet sessionPacket)
 
 void MainWindow::on_testPacketButton_clicked()
 {
+    if (ui->udptcpComboBox->currentText().contains("QUERY", Qt::CaseInsensitive)) {
+        QString dataText = ui->packetASCIIEdit->text().trimmed();
+        QDEBUG() "=== dataText: " << dataText << " isEmpty(): " << dataText.isEmpty();
+
+        if (dataText.isEmpty()) {
+            QLineEdit* field = ui->packetASCIIEdit;
+            QString originalStyle = field->styleSheet();
+            const QString orangeBorder = "QLineEdit { border: 2px solid #FF9800; }";
+
+            // Flash 4 times using singleShot (same pattern that worked before)
+            for (int i = 0; i < 4; ++i) {
+                QTimer::singleShot(i * 500, field, [field, orangeBorder]() {
+                    field->setStyleSheet(orangeBorder);
+                });
+
+                QTimer::singleShot(i * 500 + 250, field, [field, originalStyle]() {
+                    field->setStyleSheet(originalStyle);
+                });
+            }
+
+            statusBarMessage("Warning: QUERY sent with empty body. Most servers expect query data.", 4000);
+        }
+    }
+
     Packet testPacket;
     static QStringList noMCastList;
     testPacket.init();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2427,9 +2427,7 @@ void MainWindow::on_actionSettings_triggered()
     Settings settings(this);
     int accepted = settings.exec();
     if (accepted) {
-        setIPMode();
-        applyNetworkSettings();
-        loadPacketsTable();
+        updateAppAfterSettingsDialogCloses();
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1241,8 +1241,14 @@ void MainWindow::on_testPacketButton_clicked()
         QDEBUG() "=== dataText: " << dataText << " isEmpty(): " << dataText.isEmpty();
 
         if (dataText.isEmpty()) {
+            statusBar()->setStyleSheet("QStatusBar { color: #FF8800; font-weight: bold; }");
+            QThread::msleep(50); // small wait for the stylesheet to get applied before we use it
+            statusBarMessage("Warning: QUERY has empty body", 6000);
 
-            statusBarMessage("Warning: QUERY sent with empty body. Most servers expect query data.", 4000);
+            // Reset style after the message disappears
+            QTimer::singleShot(6500, this, [this]() {
+                statusBar()->setStyleSheet("");
+            });
         }
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1241,14 +1241,7 @@ void MainWindow::on_testPacketButton_clicked()
         QDEBUG() "=== dataText: " << dataText << " isEmpty(): " << dataText.isEmpty();
 
         if (dataText.isEmpty()) {
-            statusBar()->setStyleSheet("QStatusBar { color: #FF8800; font-weight: bold; }");
-            QThread::msleep(50); // small wait for the stylesheet to get applied before we use it
             statusBarMessage("Warning: QUERY has empty body", 6000);
-
-            // Reset style after the message disappears
-            QTimer::singleShot(6500, this, [this]() {
-                statusBar()->setStyleSheet("");
-            });
         }
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -60,6 +60,7 @@
 #include "cloudui.h"
 #include "postdatagen.h"
 #include "panelgenerator.h"
+#include "ui_settings.h"
 #include "wakeonlan.h"
 
 int MainWindow::isSessionOpen = false;
@@ -76,6 +77,8 @@ MainWindow::MainWindow(QWidget *parent) :
 
     ui->setupUi(this);
 
+    connect(ui->headerButton, &QPushButton::clicked,
+        this, &MainWindow::on_headersButton_clicked);
 
     QCheckBox* leaveSessionOpen;
     QCheckBox* twoVerify;
@@ -1195,6 +1198,17 @@ void MainWindow::on_savePacketButton_clicked()
     //ui->searchLineEdit->setText("");
     loadPacketsTable();
 
+}
+
+void MainWindow::on_headersButton_clicked() {
+    Settings settings(this);
+    settings.setCurrentTab("HTTP");   // or whatever the tab name/index is
+
+    int accepted = settings.exec();
+
+    if (accepted) {
+        updateAppAfterSettingsDialogCloses();
+    }
 }
 
 void MainWindow::saveSession(Packet sessionPacket)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1213,6 +1213,12 @@ void MainWindow::saveSession(Packet sessionPacket)
 
 }
 
+void MainWindow::updateAppAfterSettingsDialogCloses() {
+    setIPMode();
+    applyNetworkSettings();
+    loadPacketsTable();
+}
+
 
 void MainWindow::on_testPacketButton_clicked()
 {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1241,20 +1241,6 @@ void MainWindow::on_testPacketButton_clicked()
         QDEBUG() "=== dataText: " << dataText << " isEmpty(): " << dataText.isEmpty();
 
         if (dataText.isEmpty()) {
-            QLineEdit* field = ui->packetASCIIEdit;
-            QString originalStyle = field->styleSheet();
-            const QString orangeBorder = "QLineEdit { border: 2px solid #FF9800; }";
-
-            // Flash 4 times using singleShot (same pattern that worked before)
-            for (int i = 0; i < 4; ++i) {
-                QTimer::singleShot(i * 500, field, [field, orangeBorder]() {
-                    field->setStyleSheet(orangeBorder);
-                });
-
-                QTimer::singleShot(i * 500 + 250, field, [field, originalStyle]() {
-                    field->setStyleSheet(originalStyle);
-                });
-            }
 
             statusBarMessage("Warning: QUERY sent with empty body. Most servers expect query data.", 4000);
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1594,6 +1594,7 @@ void MainWindow::on_packetsTable_itemChanged(QTableWidgetItem *item)
             QString method = "GET";  // default
             if (upperText.contains("POST"))        method = "POST";
             else if (upperText.contains("PUT"))    method = "PUT";
+            else if (upperText.contains("QUERY"))    method = "QUERY";
             else if (upperText.contains("DELETE")) method = "DELETE";
             else if (upperText.contains("PATCH"))  method = "PATCH";
 
@@ -2757,15 +2758,16 @@ void MainWindow::on_udptcpComboBox_currentIndexChanged(const QString &arg1)
     }
 
     const auto isGet    = selectedText.contains("get");
+    const auto isQuery  = selectedText.contains("query");
     const auto isPost   = selectedText.contains("post");
     const auto isPut    = selectedText.contains("put");
     const auto isPatch  = selectedText.contains("patch");
     const auto isDelete = selectedText.contains("delete");
 
-    const bool shouldShowDataField = isPost || isPut || isPatch || isDelete;
+    const bool shouldShowDataField = isQuery || isPost || isPut || isPatch || isDelete;
 
-    // Use nice HTTP UI for GET/POST/PUT/PATCH/DELETE on both http and https
-    const bool isNiceHttpProtocol = (isHttp || isHttps) && (isGet || isPost || isPut || isPatch || isDelete);
+    // Use nice HTTP UI for GET/QUERY/POST/PUT/PATCH/DELETE on both http and https
+    const bool isNiceHttpProtocol = (isHttp || isHttps) && (isGet || isQuery || isPost || isPut || isPatch || isDelete);
 
     /////////////////////////////////dtls add line edit for adding path for cert
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -276,6 +276,7 @@ class MainWindow : public QMainWindow
 
         void setIPMode();
         void saveSession(Packet sessionPacket);
+        void updateAppAfterSettingsDialogCloses();
 
         void packetsImported(QList<Packet> packetSet);
 };

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -134,6 +134,8 @@ class MainWindow : public QMainWindow
 
         void on_savePacketButton_clicked();
 
+        void on_headersButton_clicked();
+
         void on_testPacketButton_clicked();
 
         void on_deletePacketButton_clicked();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -269,6 +269,15 @@
              </item>
              <item>
               <property name="text">
+               <string>HTTP Query</string>
+              </property>
+              <property name="icon">
+               <iconset resource="packetsender.qrc">
+                <normaloff>:/icons/tx_http.png</normaloff>:/icons/tx_http.png</iconset>
+              </property>
+             </item>
+             <item>
+              <property name="text">
                <string>HTTP Post</string>
               </property>
               <property name="icon">
@@ -306,6 +315,15 @@
              <item>
               <property name="text">
                <string>HTTPS Get</string>
+              </property>
+              <property name="icon">
+               <iconset resource="packetsender.qrc">
+                <normaloff>:/icons/tx_http.png</normaloff>:/icons/tx_http.png</iconset>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>HTTPS Query</string>
               </property>
               <property name="icon">
                <iconset resource="packetsender.qrc">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -369,6 +369,13 @@
             </widget>
            </item>
            <item>
+            <widget class="QPushButton" name="headerButton">
+             <property name="text">
+              <string>Headers</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QPushButton" name="testPacketButton">
              <property name="text">
               <string>Send</string>

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -88,6 +88,12 @@ bool Packet::isHTTPS()
 {
     return tcpOrUdp.trimmed().toLower().contains("https");
 }
+
+bool Packet::isQUERY() {
+    QDEBUG() << "isQUERY: " << (isHTTP() && tcpOrUdp.trimmed().toLower().contains("query"));
+    return  isHTTP() && tcpOrUdp.trimmed().toLower().contains("query");
+}
+
 bool Packet::isPOST()
 {
     return  isHTTP() && tcpOrUdp.trimmed().toLower().contains("post");

--- a/src/packet.h
+++ b/src/packet.h
@@ -69,6 +69,8 @@ class Packet
         bool isUDP();
         bool isHTTP();
         bool isHTTPS();
+
+        bool isQUERY();
         bool isPOST();
         bool isPUT();
         bool isDELETE();

--- a/src/packetnetwork.cpp
+++ b/src/packetnetwork.cpp
@@ -1103,12 +1103,21 @@ void PacketNetwork::packetToSend(Packet sendpacket)
 
         QHash<QString, QString> bonusHeaders = Settings::getRawHTTPHeaders(sendpacket.toIP);
 
+        QDEBUG() << "=== Bonus Headers ===";
+        QDEBUG() << "bonusHeaders.size(): " << bonusHeaders.size();
+        for (auto it = bonusHeaders.constBegin(); it != bonusHeaders.constEnd(); ++it) {
+            QDEBUG() << it.key() << ":" << it.value();
+        }
 
-        //QDEBUGVAR(sendpacket.toIP);
-        //QDEBUGVAR(sendpacket.requestPath);
         QDEBUGVAR(url);
-        //return;
+
         QNetworkRequest request = QNetworkRequest(QUrl(url));
+
+        // Apply user-defined headers first (from Settings)
+        foreach(QString key, bonusHeaders.keys()) {
+            QDEBUG()<<"Setting header" << key << bonusHeaders[key];
+            request.setRawHeader(key.toLatin1(), bonusHeaders[key].toLatin1());
+        }
 
         sendpacket.fromIP = "You";
         sendpacket.fromPort = 0;
@@ -1117,10 +1126,6 @@ void PacketNetwork::packetToSend(Packet sendpacket)
         }
 
         http->setProperty("persistent", sendpacket.persistent);
-        foreach(QString key, bonusHeaders.keys()) {
-            QDEBUG()<<"Setting header" << key << bonusHeaders[key];
-            request.setRawHeader(key.toLatin1(), bonusHeaders[key].toLatin1());
-        }
 
         if(translateMacroSend) {
             QString data = Packet::macroSwap(sendpacket.asciiString());
@@ -1130,43 +1135,49 @@ void PacketNetwork::packetToSend(Packet sendpacket)
         QByteArray bytes = sendpacket.getByteArray();
         QString bytes_trimmed = QString(bytes.trimmed());
 
-        if(sendpacket.isPOST()) {
-            request.setHeader(QNetworkRequest::ContentTypeHeader,
-                "application/x-www-form-urlencoded");
+        // === AUTO CONTENT-TYPE DETECTION (only if not already set) ===
+        bool hasBody = sendpacket.isPOST() || sendpacket.isPUT() ||
+                       sendpacket.isPATCH() || sendpacket.isQUERY() ||
+                       (sendpacket.isDELETE() && !bytes.isEmpty());
 
-            if(Settings::detectJSON_XML()) {
+        if (hasBody && !request.hasRawHeader("Content-Type")) {
 
-                if ((bytes_trimmed.startsWith("{") && bytes_trimmed.endsWith("}")) ||
-                    (bytes_trimmed.startsWith("[") && bytes_trimmed.endsWith("]")) )  {
-                    request.setHeader(QNetworkRequest::ContentTypeHeader,
-                        "application/json");
-                }
+            QString contentType = "application/x-www-form-urlencoded";
+            QString trimmed = QString(sendpacket.getByteArray()).trimmed();
 
-
-                if (bytes_trimmed.startsWith("<") && bytes_trimmed.endsWith(">")) {
-                    request.setHeader(QNetworkRequest::ContentTypeHeader,
-                        "application/xml");
+            if (Settings::detectJSON_XML()) {
+                if ((trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+                    (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+                    contentType = "application/json";
+                    }
+                else if (trimmed.startsWith("<") && trimmed.endsWith(">")) {
+                    contentType = "application/xml";
                 }
             }
 
+            QDEBUG() << "about to set Content-Type Header... contentType: " << contentType;
+            request.setHeader(QNetworkRequest::ContentTypeHeader, contentType);
+        }
 
-            QDEBUG() << "http post request";
-            http->post(request, sendpacket.getByteArray());
+        if (sendpacket.isDELETE() && bytes.isEmpty()) {
+            http->deleteResource(request);
+        }
+        else {
+            // Everything else uses sendCustomRequest
+            QByteArray verb;
 
-        } else if (sendpacket.isPUT()) {
-            http->put(request, bytes);
-        } else if (sendpacket.isPATCH()) {
-            http->sendCustomRequest(request, "PATCH", bytes);
-        } else if (sendpacket.isDELETE()) {
-            if (bytes.isEmpty()) {
-                http->deleteResource(request);
+            if (sendpacket.isPOST())      verb = "POST";
+            else if (sendpacket.isPUT())  verb = "PUT";
+            else if (sendpacket.isPATCH()) verb = "PATCH";
+            else if (sendpacket.isQUERY()) verb = "QUERY";
+            else if (sendpacket.isDELETE()) verb = "DELETE";
+
+            if (!verb.isEmpty()) {
+                QDEBUG() << "HTTP" << verb << "request";
+                http->sendCustomRequest(request, verb, bytes);
             } else {
-                http->sendCustomRequest(request, "DELETE", bytes );
+                http->get(request);
             }
-        } else
-        {
-            QDEBUG() << "http get request";
-            http->get(request);
         }
 
         emit packetSent(sendpacket);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -358,6 +358,17 @@ Settings::~Settings()
     delete ui;
 }
 
+void Settings::setCurrentTab(const QString &tabName) {
+    if (ui->settingsTabWidget) {
+        for (int i = 0; i < ui->settingsTabWidget->count(); ++i) {
+            if (ui->settingsTabWidget->tabText(i).contains(tabName, Qt::CaseInsensitive)) {
+                ui->settingsTabWidget->setCurrentIndex(i);
+                return;
+            }
+        }
+    }
+}
+
 
 bool Settings::needLanguage()
 {

--- a/src/settings.h
+++ b/src/settings.h
@@ -78,6 +78,8 @@ class Settings : public QDialog
         explicit Settings(QWidget *parent = nullptr, MainWindow* mw = nullptr);
         ~Settings();
 
+        void setCurrentTab(const QString &tabName);
+
         static QStringList defaultPacketTableHeader();
         static QStringList defaultTrafficTableHeader();
 


### PR DESCRIPTION
Before submitting a pull request:

- Did you fork from the development branch? yes 
- Are you submitting the pull request to the development branch? (not master) yes

###

# Add `QUERY` HTTP Verb
- Added QUERY method using Qt's `sendCustomRequest()`
  - (pseudo) Auto Content-Type detection for POST/PUT/PATCH/QUERY (only if not overridden on the `HTTP` tab in Settings dialog)
  - the `Data` field will "blink" an orange border around itself 4 times if you send `QUERY` without a body (the whole point of the verb is to have a body)
    - I also add a warning on the main window; maybe it needs to stay on the screen for a little longer?
-  added `Headers` button that opens the `Settings` dialog to the `HTTP` tab (which, at the time of this writing, only contains HTTP headers UI)
  - this required added a `setCurrentTab()` method to `Settings` so we can set the tab when we open the dialog
- GUI fully functional

---
# UPDATE
We're going to do a separate PR for CLI support as we need to add support for HTTP headers to CLI before we can properly support `QUERY`, otherwise all CLI sends of `QUERY` will be rejected by servers that properly handle `QUERY`.

I have CLI support for QUERY working locally (e.g. we send off the HTTP request), but ~~custom~~ headers via CLI is not yet implemented. We really need to add headers via CLI because according to [RFC 10008](https://datatracker.ietf.org/doc/rfc10008/) states that the server should reject `QUERY` if the `Content-Type` header doesn't match the type of data sent.

Question for @dannagle: 
Should we add `-H` / `--header "Key: Value"` support in this PR (similar to curl), or merge this first and do CLI headers as a quick follow-up?
